### PR TITLE
Implement disposable email validation for user sign-up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "sidekiq", "~> 6.2"
 gem "sidekiq-failures", "~> 1.0"
 gem "sidekiq-cron"
 gem 'ffi', '1.15.5'
+gem 'nondisposable'
+
 
 group :development, :test do
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    nondisposable (0.1.0)
+      rails (>= 7.0.0)
     orm_adapter (0.5.0)
     ostruct (0.6.0)
     pg (1.5.8)
@@ -374,6 +376,7 @@ DEPENDENCIES
   groupdate
   importmap-rails
   jbuilder
+  nondisposable
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.0.rc1)

--- a/app/jobs/disposable_email_domain_list_update_job.rb
+++ b/app/jobs/disposable_email_domain_list_update_job.rb
@@ -1,0 +1,7 @@
+class DisposableEmailDomainListUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Nondisposable::DomainListUpdater.update
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   has_many :subscriptions, dependent: :destroy
 
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, uniqueness: true, nondisposable: { message: "is a disposable email address, please use a permanent email address." }
 
   def due_dates
     subscriptions.map{ |subscription| subscription.payment_date.day }

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -1,0 +1,10 @@
+Nondisposable.configure do |config|
+  # Customize the error message if needed
+  # config.error_message = "is not allowed. Please use a non-disposable email address."
+  #
+  # Add custom domains you want to be considered as disposable
+  # config.additional_domains = ['custom-disposable-domain.com']
+  #
+  # Exclude domains that are considered disposable but you want to allow anyways
+  # config.excluded_domains = ['false-positive-domain.com']
+end

--- a/db/migrate/20241101001439_create_nondisposable_disposable_domains.rb
+++ b/db/migrate/20241101001439_create_nondisposable_disposable_domains.rb
@@ -1,0 +1,21 @@
+class CreateNondisposableDisposableDomains < ActiveRecord::Migration[8.0]
+  def change
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :nondisposable_disposable_domains, id: primary_key_type do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_03_14_134314) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_01_001439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -45,6 +45,13 @@ ActiveRecord::Schema[8.0].define(version: 2024_03_14_134314) do
   create_table "emails", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "nondisposable_disposable_domains", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_nondisposable_disposable_domains_on_name", unique: true
   end
 
   create_table "subscriptions", force: :cascade do |t|


### PR DESCRIPTION

- Added the nondisposable gem to validate non-disposable email addresses during user registration.
- Configured validation in User model to ensure only non-disposable emails are accepted.
- Added a background job DisposableEmailDomainListUpdateJob to periodically update the list of disposable domains using Nondisposable::DomainListUpdater.
-Created a migration to support the nondisposable gem’s disposable domain list in the database.
-Configured initializer nondisposable.rb for custom settings, if needed.

TLDR :)  email validation security by blocking disposable email addresses and ensure regular updates to the domain list.






